### PR TITLE
fix: pip exit 1 when pip_requirements is empty

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -132,6 +132,8 @@ def generate_dockerfile(problems):
 
     if len(dockerfile_data['pip_list']) > 0:
         dockerfile_data['pip_requirements'] = ' '.join(dockerfile_data['pip_list'])
+    else:
+        dockerfile_data['pip_requirements'] = 'pip'
 
     dockerfile_data['chmod_cmd'] = "RUN " + ' && \\\n '.join(dockerfile_data['chmod_cmds'])
 


### PR DESCRIPTION
Fixed with a relief solution.

## Error log
```
Step 7/17 : RUN python -m pip install --no-cache-dir --upgrade pip
 ---> Running in 228de14ff2e7
Requirement already satisfied: pip in /usr/local/lib/python3.10/site-packages (21.2.4)
Collecting pip
  Downloading pip-22.0-py3-none-any.whl (2.1 MB)
Installing collected packages: pip
  Attempting uninstall: pip
    Found existing installation: pip 21.2.4
    Uninstalling pip-21.2.4:
      Successfully uninstalled pip-21.2.4
Successfully installed pip-22.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
Removing intermediate container 228de14ff2e7
 ---> 518a667884bb
Step 8/17 : RUN python -m pip install --no-cache-dir
 ---> Running in 1fcc821c657d
ERROR: You must give at least one requirement to install (see "pip help install")
ERROR: Service 'nc_docker' failed to build : The command '/bin/sh -c python -m pip install --no-cache-dir' returned a non-zero code: 1
Error occured, exiting...
```